### PR TITLE
Tweak QMK update steps for firmware v25

### DIFF
--- a/.github/workflows/fetch-and-build-layout.yml
+++ b/.github/workflows/fetch-and-build-layout.yml
@@ -77,9 +77,10 @@ jobs:
 
       - name: Update QMK firmware submodule to latest version (${{ steps.download-layout-source.outputs.firmware_version }})
         run: |
-          git submodule update --init --remote --depth=1
+          git submodule update --init --remote --depth=1 --no-single-branch
           cd qmk_firmware
           git checkout -B firmware${{ steps.download-layout-source.outputs.firmware_version }} origin/firmware${{ steps.download-layout-source.outputs.firmware_version }}
+          sed -ie 's!git@github.com:!https://github.com/!' .gitmodules
           git submodule update --init --recursive
           cd ..
           git add qmk_firmware


### PR DESCRIPTION
Make 2 changes to the "Update QMK firmware" step:

- Use `--no-single-branch` when updating the top-level submodule, otherwise `--depth=1` will only fetch the latest commit. That can cause checkouts to fail if the Oryx layout moves to a newer firmware version.

- Replace any SSH URLs in qmk_firmware submodules with HTTPS. Since we're dealing with public repos, it's a bit less friction than setting up an SSH agent in the context of a job step.